### PR TITLE
Fix missing comma in send grid configure

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -99,7 +99,7 @@ Rails.application.configure do
   config.action_mailer.smtp_settings = {
     :user_name => ENV['SENDGRID_USERNAME'],
     :password => ENV['SENDGRID_PASSWORD'],
-    :domain => 'example.com'
+    :domain => 'example.com',
     :address => 'smtp.sendgrid.net',
     :port => 587,
     :authentication => :plain,


### PR DESCRIPTION
Fixes missing comma in send grid configure that is causing heroku to fail on the build